### PR TITLE
Fixed waterbreathing mask bug

### DIFF
--- a/OSIProject (Legacy)/class/mask.osas
+++ b/OSIProject (Legacy)/class/mask.osas
@@ -817,6 +817,13 @@ begin class "mask"
 		PushConstanti8                10
 		CallGameFunctionString        "gccharacter", "setwatertimerlength", 2
 		Pop
+		GetVariableValueGlobalString  "globalclass"
+		GetMemberValueString          "player"
+		GetMemberValueString          "actor"
+		Dup
+		GetMemberFunctionString       "replenishair"
+		JumpAbsolute                  1
+		Pop
 		; <-
 		BranchTarget                  15
 		BranchAlwaysTarget            39, 0


### PR DESCRIPTION
- Reset the air meter afterwards so the player gets a full meter to work with after turning the mask back off.